### PR TITLE
eFTL JS: add support for web worker

### DIFF
--- a/eftl-javascript-sdk/eftl.js
+++ b/eftl-javascript-sdk/eftl.js
@@ -191,8 +191,11 @@ var WebSocket = WebSocket || require('ws');
       // Node.js
       var url = require('url');
       return url.parse(str);
+    } else if ("function" == typeof URL) {
+        // modern browser and web worker thread
+        return new URL(str);
     } else {
-      // browser
+      // fallback for older browser
       var url = document.createElement('a');
       url.href = str;
       url.query = (url.search && url.search.charAt(0) === '?' ? url.search.substring(1) : url.search);


### PR DESCRIPTION
Because in webworker: https://www.w3schools.com/html/html5_webworkers.asp
there is no support for "document"

But for modern browser there is a new way to parse URLs.
https://developer.mozilla.org/en-US/docs/Web/API/URL/URL

Using this makes eFTL compatible to WebWorker except the InternetExplorer.
